### PR TITLE
remove deleted examples (moving to piccolo)

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,9 +13,6 @@ hero:
     - theme: alt
       text: Research
       link: /collaborations.html#research
-    - theme: alt
-      text: Examples
-      link: https://kestrelquantum.github.io/Piccolo.jl/QuantumCollocation/dev/generated/examples/two_qubit_gates/
 
 features:
   - title: Piccolo.jl


### PR DESCRIPTION
We will be moving these examples into the piccolo package docs instead of living in QC. Removing Link for now